### PR TITLE
fix: replace broken subgraph dependencies with on-chain reads

### DIFF
--- a/codegen.ts
+++ b/codegen.ts
@@ -6,41 +6,6 @@ dotenv.config();
 
 const config: CodegenConfig = {
   generates: {
-    "./src/data/generated/gql/": {
-      documents: [
-        "src/**/*.{ts,tsx}",
-        "!src/data/generated/**/*",
-        "!src/data/ponder/**/*",
-        "!src/data/cms/**/*",
-      ],
-      schema: `https://api.goldsky.com/api/public/project_cldf2o9pqagp43svvbk5u3kmo/subgraphs/nouns/prod/gn`,
-      preset: "client",
-      plugins: [],
-      config: {
-        documentMode: "string",
-        scalars: {
-          BigDecimal: {
-            input: "string",
-            output: "string",
-          },
-          BigInt: {
-            input: "string",
-            output: "string",
-          },
-          Int8: {
-            input: "any",
-            output: "string",
-          },
-          Bytes: {
-            input: "any",
-            output: "string",
-          },
-        },
-        mappers: {
-          BigInt: "bigint",
-        },
-      },
-    },
     "./src/data/generated/ponder/": {
       documents: ["src/data/ponder/**/*"],
       schema: CHAIN_CONFIG.ponderIndexerUrl,

--- a/src/components/FloatingNounsBackground.tsx
+++ b/src/components/FloatingNounsBackground.tsx
@@ -26,6 +26,7 @@ export function FloatingNounsBackground({
   const [randomNouns, setRandomNouns] = useState<Noun[]>([]);
 
   useEffect(() => {
+    if (nouns.length === 0) return;
     // Generate the random nouns once on the client
     setRandomNouns(
       Array.from(

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,10 +38,6 @@ export interface ChainSpecificData {
     stEth: Address;
   };
   nounsGovernanceUrl: string;
-  subgraphUrl: {
-    primary: string;
-    fallback: string;
-  };
   ponderIndexerUrl: string;
   swapForWrappedNativeUrl: string;
   reservoirApiUrl: string;
@@ -100,11 +96,6 @@ const CHAIN_SPECIFIC_CONFIGS: Record<number, ChainSpecificData> = {
       stEth: getAddress("0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"),
     },
     nounsGovernanceUrl: "https://nouns.camp/",
-    subgraphUrl: {
-      primary:
-        "https://api.goldsky.com/api/public/project_cldf2o9pqagp43svvbk5u3kmo/subgraphs/nouns/prod/gn",
-      fallback: `https://gateway-arbitrum.network.thegraph.com/api/${process.env.DECENTRALIZED_SUBGRAPH_API_KEY}/deployments/id/Qmdfajyi6PSmc45xWpbZoYdses84SAAze6ZcCxuDAhJFzt`,
-    },
     ponderIndexerUrl: process.env.INDEXER_URL!,
     swapForWrappedNativeUrl:
       "https://app.uniswap.org/swap?outputCurrency=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&chain=mainnet",
@@ -140,10 +131,6 @@ const CHAIN_SPECIFIC_CONFIGS: Record<number, ChainSpecificData> = {
       stEth: getAddress("0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"), // TODO: update
     },
     nounsGovernanceUrl: "https://sepolia.nouns.camp/",
-    subgraphUrl: {
-      primary: `https://api.studio.thegraph.com/query/35078/nouns-sepolia/v1.0.0`,
-      fallback: `https://gateway-arbitrum.network.thegraph.com/api/${process.env.DECENTRALIZED_SUBGRAPH_API_KEY}/deployments/id/QmZNg1ngfNLpYxVQGCqbxWhqNLsiup3oSGbWpkF8tERVa6`,
-    },
     ponderIndexerUrl: process.env.INDEXER_URL!, // mainnet for now, didn't deploy for sepolia yet, don't use for testnet but this satisfies codegen
     swapForWrappedNativeUrl: "",
     reservoirApiUrl: "https://api-sepolia.reservoir.tools",

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,7 +28,7 @@ export interface ChainSpecificData {
     nounsToken: Address;
     nounsTreasury: Address; // a.k.a NounsDAOExecutor, which is the treasury time lock
     nounsDoaProxy: Address; // GovernorBravoDelegator, proxy to logic contract
-    nounsDoaDataProxy: Address; // proxy to NounsDAOData.sol contract, which
+    nounsDoaDataProxy: Address; // proxy to NounsDAOData.sol contract
     nounsAuctionHouseProxy: Address;
     nounsErc20: Address;
     wrappedNativeToken: Address;
@@ -47,25 +47,35 @@ export interface ChainSpecificData {
   reservoirApiUrl: string;
 }
 
-export const mainnetPublicClient = createClient({
-  chain: mainnet,
-  transport: fallback([
-    http(
-      `https://eth-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY!}`,
-    ),
-    http(
-      `https://mainnet.infura.io/v3/${process.env.NEXT_PUBLIC_INFURA_API_KEY!}`,
-    ),
-  ]),
-});
+function createPublicClient(chain: Chain, rpcUrl: { primary: string; fallback: string }): Client {
+  return createClient({
+    chain,
+    transport: fallback([
+      http(rpcUrl.primary, { batch: true }),
+      http(rpcUrl.fallback, { batch: true }),
+    ]),
+    batch: {
+      multicall: true,
+    },
+  });
+}
+
+const MAINNET_RPC_URL = {
+  primary: `https://eth-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY!}`,
+  fallback: `https://mainnet.infura.io/v3/${process.env.NEXT_PUBLIC_INFURA_API_KEY!}`,
+};
+
+export const mainnetPublicClient = createPublicClient(mainnet, MAINNET_RPC_URL);
+
+const SEPOLIA_RPC_URL = {
+  primary: `https://eth-sepolia.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY!}`,
+  fallback: `https://sepolia.infura.io/v3/${process.env.NEXT_PUBLIC_INFURA_API_KEY!}`,
+};
 
 const CHAIN_SPECIFIC_CONFIGS: Record<number, ChainSpecificData> = {
   [mainnet.id]: {
     chain: mainnet,
-    rpcUrl: {
-      primary: `https://eth-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY!}`,
-      fallback: `https://mainnet.infura.io/v3/${process.env.NEXT_PUBLIC_INFURA_API_KEY!}`,
-    },
+    rpcUrl: MAINNET_RPC_URL,
     publicClient: mainnetPublicClient,
     reservoirChain: { ...reservoirChains.mainnet, active: true },
     addresses: {
@@ -102,21 +112,8 @@ const CHAIN_SPECIFIC_CONFIGS: Record<number, ChainSpecificData> = {
   },
   [sepolia.id]: {
     chain: sepolia,
-    rpcUrl: {
-      primary: `https://eth-sepolia.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY!}`,
-      fallback: `https://sepolia.infura.io/v3/${process.env.NEXT_PUBLIC_INFURA_API_KEY!}`,
-    },
-    publicClient: createClient({
-      chain: sepolia,
-      transport: fallback([
-        http(
-          `https://eth-sepolia.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY!}`,
-        ),
-        http(
-          `https://sepolia.infura.io/v3/${process.env.NEXT_PUBLIC_INFURA_API_KEY!}`,
-        ),
-      ]),
-    }),
+    rpcUrl: SEPOLIA_RPC_URL,
+    publicClient: createPublicClient(sepolia, SEPOLIA_RPC_URL),
     reservoirChain: {
       ...reservoirChains.sepolia,
       active: true,

--- a/src/data/auction/getAuctionById.ts
+++ b/src/data/auction/getAuctionById.ts
@@ -6,55 +6,9 @@ import { Hex, getAddress } from "viem";
 import { getProtocolParams } from "../protocol/getProtocolParams";
 import { bigIntMax } from "@/utils/bigint";
 import { revalidateTag, unstable_cache } from "next/cache";
-import { graphQLFetch } from "../utils/graphQLFetch";
-import { TypedDocumentString } from "../generated/ponder/graphql";
+import { fetchAuctionByNounId } from "../ponder/auction/getAuctionByNounId";
 
 const NOUNDER_AUCTION_CUTOFF = BigInt(1820);
-
-interface PonderAuctionResult {
-  auction: {
-    nounsNftId: string;
-    startTimestamp: number;
-    endTimestamp: number;
-    settled: boolean;
-    bids: {
-      items: Array<{
-        transactionHash: string;
-        bidderAccountAddress: string;
-        amount: string;
-        timestamp: number;
-        clientId: number | null;
-      }>;
-    };
-  } | null;
-}
-
-interface PonderAuctionVariables {
-  nounId: string;
-}
-
-const ponderAuctionQuery = new TypedDocumentString<
-  PonderAuctionResult,
-  PonderAuctionVariables
->(`
-  query AuctionById($nounId: BigInt!) {
-    auction(nounsNftId: $nounId) {
-      nounsNftId
-      startTimestamp
-      endTimestamp
-      settled
-      bids(limit: 1000, orderBy: "amount", orderDirection: "desc") {
-        items {
-          transactionHash
-          bidderAccountAddress
-          amount
-          timestamp
-          clientId
-        }
-      }
-    }
-  }
-`);
 
 async function getAuctionByIdUncached(
   id: BigIntString,
@@ -80,12 +34,7 @@ async function getAuctionByIdUncached(
   }
 
   const [result, params] = await Promise.all([
-    graphQLFetch(
-      CHAIN_CONFIG.ponderIndexerUrl,
-      ponderAuctionQuery,
-      { nounId: id },
-      { cache: "no-cache" },
-    ),
+    fetchAuctionByNounId(id),
     getProtocolParams(),
   ]);
 
@@ -95,7 +44,7 @@ async function getAuctionByIdUncached(
     return undefined;
   }
 
-  const bids: Bid[] = auction.bids.items.map((bid) => ({
+  const bids: Bid[] = (auction.bids?.items ?? []).map((bid) => ({
     transactionHash: bid.transactionHash as Hex,
     bidderAddress: getAddress(bid.bidderAccountAddress),
     amount: bid.amount,

--- a/src/data/auction/getAuctionById.ts
+++ b/src/data/auction/getAuctionById.ts
@@ -1,6 +1,4 @@
 "use server";
-import { graphql } from "../generated/gql";
-import { graphQLFetchWithFallback } from "../utils/graphQLFetch";
 import { CHAIN_CONFIG } from "@/config";
 import { BigIntString } from "@/utils/types";
 import { Auction, Bid } from "./types";
@@ -8,32 +6,51 @@ import { Hex, getAddress } from "viem";
 import { getProtocolParams } from "../protocol/getProtocolParams";
 import { bigIntMax } from "@/utils/bigint";
 import { revalidateTag, unstable_cache } from "next/cache";
+import { graphQLFetch } from "../utils/graphQLFetch";
+import { TypedDocumentString } from "../generated/ponder/graphql";
 
 const NOUNDER_AUCTION_CUTOFF = BigInt(1820);
 
-const query = graphql(/* GraphQL */ `
-  query Auction($id: ID!) {
-    auction(id: $id) {
-      id
-      noun {
-        id
-      }
-      amount
-      startTime
-      endTime
-      bidder {
-        id
-      }
-      clientId
+interface PonderAuctionResult {
+  auction: {
+    nounsNftId: string;
+    startTimestamp: number;
+    endTimestamp: number;
+    settled: boolean;
+    bids: {
+      items: Array<{
+        transactionHash: string;
+        bidderAccountAddress: string;
+        amount: string;
+        timestamp: number;
+        clientId: number | null;
+      }>;
+    };
+  } | null;
+}
+
+interface PonderAuctionVariables {
+  nounId: string;
+}
+
+const ponderAuctionQuery = new TypedDocumentString<
+  PonderAuctionResult,
+  PonderAuctionVariables
+>(`
+  query AuctionById($nounId: BigInt!) {
+    auction(nounsNftId: $nounId) {
+      nounsNftId
+      startTimestamp
+      endTimestamp
       settled
-      bids {
-        txHash
-        bidder {
-          id
+      bids(limit: 1000, orderBy: "amount", orderDirection: "desc") {
+        items {
+          transactionHash
+          bidderAccountAddress
+          amount
+          timestamp
+          clientId
         }
-        amount
-        blockTimestamp
-        clientId
       }
     }
   }
@@ -42,12 +59,9 @@ const query = graphql(/* GraphQL */ `
 async function getAuctionByIdUncached(
   id: BigIntString,
 ): Promise<Auction | undefined> {
-  if (
-    BigInt(id) <= NOUNDER_AUCTION_CUTOFF &&
-    BigInt(id) % BigInt(10) == BigInt(0)
-  ) {
+  if (BigInt(id) <= NOUNDER_AUCTION_CUTOFF && BigInt(id) % 10n === 0n) {
     const nextNoun = await getAuctionByIdUncached(
-      (BigInt(id) + BigInt(1)).toString(),
+      (BigInt(id) + 1n).toString(),
     );
     return {
       nounId: id,
@@ -66,11 +80,11 @@ async function getAuctionByIdUncached(
   }
 
   const [result, params] = await Promise.all([
-    graphQLFetchWithFallback(
-      CHAIN_CONFIG.subgraphUrl,
-      query,
-      { id },
-      { next: { revalidate: 0 } },
+    graphQLFetch(
+      CHAIN_CONFIG.ponderIndexerUrl,
+      ponderAuctionQuery,
+      { nounId: id },
+      { cache: "no-cache" },
     ),
     getProtocolParams(),
   ]);
@@ -81,11 +95,11 @@ async function getAuctionByIdUncached(
     return undefined;
   }
 
-  const bids: Bid[] = auction.bids.map((bid: any) => ({
-    transactionHash: bid.txHash as Hex,
-    bidderAddress: getAddress(bid.bidder.id),
+  const bids: Bid[] = auction.bids.items.map((bid) => ({
+    transactionHash: bid.transactionHash as Hex,
+    bidderAddress: getAddress(bid.bidderAccountAddress),
     amount: bid.amount,
-    timestamp: bid.blockTimestamp,
+    timestamp: bid.timestamp.toString(),
     clientId: bid.clientId ?? undefined,
   }));
 
@@ -93,35 +107,34 @@ async function getAuctionByIdUncached(
   bids.sort((a, b) => (BigInt(b.amount) > BigInt(a.amount) ? 1 : -1));
 
   const highestBidAmount =
-    auction.bids.length > 0 ? BigInt(bids[0].amount) : BigInt(0);
+    bids.length > 0 ? BigInt(bids[0].amount) : 0n;
   const nextMinBid = bigIntMax(
     BigInt(params.reservePrice),
     highestBidAmount +
-      (highestBidAmount * BigInt(params.minBidIncrementPercentage)) /
-        BigInt(100),
+      (highestBidAmount * BigInt(params.minBidIncrementPercentage)) / 100n,
   );
 
   const nowS = Date.now() / 1000;
-  const ended = nowS > Number(auction.endTime);
+  const ended = nowS > Number(auction.endTimestamp);
+
+  let state: Auction["state"];
+  if (!ended) {
+    state = "live";
+  } else if (auction.settled) {
+    state = "ended-settled";
+  } else {
+    state = "ended-unsettled";
+  }
 
   return {
-    nounId: auction.noun.id,
-
-    startTime: auction.startTime,
-    endTime: auction.endTime,
-
+    nounId: auction.nounsNftId,
+    startTime: auction.startTimestamp.toString(),
+    endTime: auction.endTimestamp.toString(),
     nextMinBid: nextMinBid.toString(),
-
-    state: ended
-      ? auction.settled
-        ? "ended-settled"
-        : "ended-unsettled"
-      : "live",
-
+    state,
     bids,
-
     nounderAuction: false,
-  } as Auction;
+  };
 }
 
 const getAuctionByIdCached = unstable_cache(
@@ -132,10 +145,10 @@ const getAuctionByIdCached = unstable_cache(
   },
 );
 
-export async function getAuctionById(id: BigIntString) {
+export async function getAuctionById(id: BigIntString): Promise<Auction | undefined> {
   const cachedAuction = await getAuctionByIdCached(id);
 
-  if (cachedAuction?.state != "ended-settled") {
+  if (cachedAuction?.state !== "ended-settled") {
     revalidateTag("get-auction-by-id");
     return await getAuctionByIdCached(id);
   }

--- a/src/data/auction/getCurrentAuctionNounId.ts
+++ b/src/data/auction/getCurrentAuctionNounId.ts
@@ -1,24 +1,24 @@
 "use server";
 import { BigIntString } from "@/utils/types";
 import { CHAIN_CONFIG } from "@/config";
-import { graphql } from "../generated/gql";
-import { graphQLFetchWithFallback } from "../utils/graphQLFetch";
+import { nounsAuctionHouseAbi } from "@/abis/nounsAuctionHouse";
+import { readContract } from "viem/actions";
+import { unstable_cache } from "next/cache";
 
-const query = graphql(/* GraphQL */ `
-  query CurrentAuctionId {
-    auctions(orderBy: endTime, orderDirection: desc, first: 1) {
-      id
-    }
-  }
-`);
-
-export async function getCurrentAuctionNounId(): Promise<BigIntString> {
-  const result = await graphQLFetchWithFallback(
-    CHAIN_CONFIG.subgraphUrl,
-    query,
-    {},
-    { next: { revalidate: 2 } },
-  );
-  const currentAuction = result?.auctions?.[0] ?? null;
-  return currentAuction?.id ?? "1";
+async function fetchCurrentAuctionNounId(): Promise<BigIntString> {
+  const auction = await readContract(CHAIN_CONFIG.publicClient, {
+    address: CHAIN_CONFIG.addresses.nounsAuctionHouseProxy,
+    abi: nounsAuctionHouseAbi,
+    functionName: "auction",
+  });
+  return auction.nounId.toString();
 }
+
+// Auction ID changes ~daily. Short TTL provides stale-while-revalidate
+// resilience: if the RPC is temporarily down, the cached value (still
+// correct) is served instead of crashing every page that uses this.
+export const getCurrentAuctionNounId = unstable_cache(
+  fetchCurrentAuctionNounId,
+  ["get-current-auction-noun-id"],
+  { revalidate: 60 },
+);

--- a/src/data/getNounSwapProposalsForProposer.ts
+++ b/src/data/getNounSwapProposalsForProposer.ts
@@ -3,57 +3,9 @@ import { ProposalState, SwapNounProposal } from "../utils/types";
 import { Address } from "viem";
 import { getNounById } from "./noun/getNounById";
 import { CHAIN_CONFIG } from "../config";
-import { graphQLFetch } from "./utils/graphQLFetch";
-import { TypedDocumentString, LastKnownProposalState } from "./generated/ponder/graphql";
+import { LastKnownProposalState } from "./generated/ponder/graphql";
 import { getBlockNumber } from "viem/actions";
-
-interface PonderProposalsResult {
-  proposals: {
-    items: Array<{
-      id: number;
-      title: string;
-      description: string;
-      proposerAddress: string;
-      quorumVotes: number;
-      forVotes: number;
-      againstVotes: number;
-      lastKnownState: LastKnownProposalState;
-      votingStartBlock: number;
-      votingEndBlock: number;
-    }>;
-  };
-}
-
-interface PonderProposalsVariables {
-  proposer: string;
-}
-
-const ponderProposalsQuery = new TypedDocumentString<
-  PonderProposalsResult,
-  PonderProposalsVariables
->(`
-  query NounSwapProposals($proposer: String!) {
-    proposals(
-      limit: 1000
-      where: { proposerAddress: $proposer, title_contains: "NounSwap" }
-      orderBy: "id"
-      orderDirection: "desc"
-    ) {
-      items {
-        id
-        title
-        description
-        proposerAddress
-        quorumVotes
-        forVotes
-        againstVotes
-        lastKnownState
-        votingStartBlock
-        votingEndBlock
-      }
-    }
-  }
-`);
+import { fetchNounSwapProposals } from "./ponder/governance/getNounSwapProposals";
 
 // Title format patterns for NounSwap proposals:
 //   "NounSwap v1: Swap Noun X + Y WETH for Noun Z"
@@ -111,12 +63,7 @@ export async function getNounSwapProposalsForProposer(address: Address): Promise
   const proposer = address.toString().toLowerCase();
   const currentBlock = await getBlockNumber(CHAIN_CONFIG.publicClient);
 
-  const queryResult = await graphQLFetch(
-    CHAIN_CONFIG.ponderIndexerUrl,
-    ponderProposalsQuery,
-    { proposer },
-    { cache: "no-cache" },
-  );
+  const queryResult = await fetchNounSwapProposals(proposer);
 
   if (!queryResult) {
     console.log(`getNounSwapProposalsForProposer: no proposals found - ${address}`);

--- a/src/data/getNounSwapProposalsForProposer.ts
+++ b/src/data/getNounSwapProposalsForProposer.ts
@@ -3,180 +3,156 @@ import { ProposalState, SwapNounProposal } from "../utils/types";
 import { Address } from "viem";
 import { getNounById } from "./noun/getNounById";
 import { CHAIN_CONFIG } from "../config";
-import { graphql } from "./generated/gql";
-import { ProposalStatus } from "./generated/gql/graphql";
-import { graphQLFetchWithFallback } from "./utils/graphQLFetch";
+import { graphQLFetch } from "./utils/graphQLFetch";
+import { TypedDocumentString, LastKnownProposalState } from "./generated/ponder/graphql";
 import { getBlockNumber } from "viem/actions";
 
-const query = graphql(`
-  query NounSwapProposalsForProposer($proposerAsString: String!, $proposerAsBytes: Bytes!) {
+interface PonderProposalsResult {
+  proposals: {
+    items: Array<{
+      id: number;
+      title: string;
+      description: string;
+      proposerAddress: string;
+      quorumVotes: number;
+      forVotes: number;
+      againstVotes: number;
+      lastKnownState: LastKnownProposalState;
+      votingStartBlock: number;
+      votingEndBlock: number;
+    }>;
+  };
+}
+
+interface PonderProposalsVariables {
+  proposer: string;
+}
+
+const ponderProposalsQuery = new TypedDocumentString<
+  PonderProposalsResult,
+  PonderProposalsVariables
+>(`
+  query NounSwapProposals($proposer: String!) {
     proposals(
-      where: { proposer: $proposerAsString, title_contains: "NounSwap" }
-      first: 1000
-      orderBy: id
-      orderDirection: desc
+      limit: 1000
+      where: { proposerAddress: $proposer, title_contains: "NounSwap" }
+      orderBy: "id"
+      orderDirection: "desc"
     ) {
-      id
-      title
-      description
-      status
-      quorumVotes
-      forVotes
-      againstVotes
-      endBlock
-      startBlock
-    }
-    proposalCandidates(
-      where: { proposer: $proposerAsBytes, slug_contains: "nounswap" }
-      first: 1000
-      orderBy: createdTimestamp
-      orderDirection: desc
-    ) {
-      id
-      slug
+      items {
+        id
+        title
+        description
+        proposerAddress
+        quorumVotes
+        forVotes
+        againstVotes
+        lastKnownState
+        votingStartBlock
+        votingEndBlock
+      }
     }
   }
 `);
+
+// Title format patterns for NounSwap proposals:
+//   "NounSwap v1: Swap Noun X + Y WETH for Noun Z"
+//   "NounSwap v1: Swap Noun X for Noun Y"
+//   "NounSwap: Swap Noun X for Noun Y"
+const TITLE_PATTERNS = [
+  { regex: /NounSwap v1: Swap Noun [0-9]* \+ [0-9]*\.?[0-9]*? WETH for Noun [0-9]*/, fromIndex: 4, toIndex: 10 },
+  { regex: /NounSwap v1: Swap Noun [0-9]* for Noun [0-9]*/, fromIndex: 4, toIndex: 7 },
+  { regex: /NounSwap: Swap Noun [0-9]* for Noun [0-9]*/, fromIndex: 3, toIndex: 6 },
+] as const;
+
+function parseSwapNounIds(title: string): { fromNounId: string; toNounId: string } | undefined {
+  for (const pattern of TITLE_PATTERNS) {
+    const match = title.match(pattern.regex);
+    if (match === null || match.length === 0) continue;
+
+    const split = match[0].split(" ");
+    return { fromNounId: split[pattern.fromIndex], toNounId: split[pattern.toIndex] };
+  }
+  return undefined;
+}
+
+function resolveProposalState(
+  lastKnownState: LastKnownProposalState,
+  currentBlock: bigint,
+  votingStartBlock: number,
+  votingEndBlock: number,
+  forVotes: number,
+  againstVotes: number,
+  quorumVotes: number,
+): ProposalState {
+  switch (lastKnownState) {
+    case LastKnownProposalState.Cancelled:
+      return ProposalState.Cancelled;
+    case LastKnownProposalState.Executed:
+      return ProposalState.Executed;
+    case LastKnownProposalState.Queued:
+      return ProposalState.Queued;
+    case LastKnownProposalState.Vetoed:
+      return ProposalState.Vetoed;
+    case LastKnownProposalState.Updatable:
+    default: {
+      const ended = currentBlock > BigInt(votingEndBlock);
+      if (!ended) {
+        const started = currentBlock > BigInt(votingStartBlock);
+        return started ? ProposalState.Active : ProposalState.Pending;
+      }
+      const passing = forVotes >= quorumVotes && forVotes > againstVotes;
+      return passing ? ProposalState.Succeeded : ProposalState.Defeated;
+    }
+  }
+}
 
 export async function getNounSwapProposalsForProposer(address: Address): Promise<SwapNounProposal[]> {
   const proposer = address.toString().toLowerCase();
   const currentBlock = await getBlockNumber(CHAIN_CONFIG.publicClient);
 
-  const queryResult = await graphQLFetchWithFallback(
-    CHAIN_CONFIG.subgraphUrl,
-    query,
-    {
-      proposerAsString: proposer,
-      proposerAsBytes: proposer,
-    },
-    { next: { revalidate: 0 } }
+  const queryResult = await graphQLFetch(
+    CHAIN_CONFIG.ponderIndexerUrl,
+    ponderProposalsQuery,
+    { proposer },
+    { cache: "no-cache" },
   );
 
-  if (queryResult) {
-    const proposals = queryResult.proposals;
-    const proposalCandidates = queryResult.proposalCandidates;
-
-    const swapNounProposals: SwapNounProposal[] = [];
-
-    for (let proposal of proposals) {
-      const title = proposal.title;
-
-      let fromNounId = "";
-      let toNounId = "";
-
-      let match = title.match(/NounSwap v1: Swap Noun [0-9]* \+ [0-9]*\.?[0-9]*? WETH for Noun [0-9]*/); // NounSwap v1: Swap Noun XX + ZZ WETH for Noun YY
-      if (match != null && match.length != 0) {
-        const split = match[0].split(" ");
-        fromNounId = split[4];
-        toNounId = split[10];
-      } else {
-        match = title.match(/NounSwap v1: Swap Noun [0-9]* for Noun [0-9]*/); // NounSwap v1: Swap Noun XX for Noun YY (no WETH)
-        if (match != null && match.length != 0) {
-          const split = match[0].split(" ");
-          fromNounId = split[4];
-          toNounId = split[7];
-        } else {
-          match = title.match(/NounSwap: Swap Noun [0-9]* for Noun [0-9]*/); // NounSwap: Swap Noun XX for Noun YY
-          if (match == null || match.length == 0) {
-            continue;
-          }
-          const split = match[0].split(" ");
-          fromNounId = split[3];
-          toNounId = split[6];
-        }
-      }
-
-      const fromNoun = await getNounById(fromNounId);
-      const toNoun = await getNounById(toNounId);
-
-      const started = currentBlock > BigInt(proposal.startBlock);
-      const ended = currentBlock > BigInt(proposal.endBlock);
-      const passing = proposal.forVotes >= proposal.quorumVotes! && proposal.forVotes > proposal.againstVotes;
-
-      // Compute actual state, subgraph can't know with Active and Pending since no events
-      let state: ProposalState = ProposalState.Cancelled;
-      switch (proposal.status) {
-        case ProposalStatus.Cancelled:
-          state = ProposalState.Cancelled;
-          break;
-        case ProposalStatus.Executed:
-          state = ProposalState.Executed;
-          break;
-        case ProposalStatus.Queued:
-          state = ProposalState.Queued;
-          break;
-        case ProposalStatus.Vetoed:
-          state = ProposalState.Vetoed;
-          break;
-        case ProposalStatus.Active:
-          if (ended) {
-            state = passing ? ProposalState.Succeeded : ProposalState.Defeated;
-          } else {
-            state = ProposalState.Active;
-          }
-          break;
-        case ProposalStatus.Pending:
-          if (ended) {
-            state = ProposalState.Defeated;
-          } else if (started) {
-            state = ProposalState.Active;
-          } else {
-            state = ProposalState.Pending;
-          }
-          break;
-      }
-
-      swapNounProposals.push({
-        id: Number(proposal.id),
-        fromNoun: fromNoun,
-        toNoun: toNoun,
-        state: state,
-      } as SwapNounProposal);
-    }
-
-    const swapNounCandidates: SwapNounProposal[] = [];
-    for (let proposalCandidate of proposalCandidates) {
-      // Only v1 supports candidates
-
-      const match = proposalCandidate.slug.match(/nounswap-v1-swap-noun-[0-9]*--[0-9]*\.?[0-9]*?-weth-for-noun-[0-9]*/); // NounSwap v1: Swap Noun XX + ZZ WETH for Noun YY
-
-      let fromNounId = "";
-      let toNounId = "";
-      if (match != null && match.length != 0) {
-        const split = match[0].split("-");
-        fromNounId = split[4];
-        toNounId = split[10];
-      } else {
-        const match = proposalCandidate.slug.match(/nounswap-v1-swap-noun-[0-9]*-for-noun-[0-9]*/); // NounSwap v1: Swap Noun XX + ZZ WETH for Noun YY
-        if (match != null && match.length != 0) {
-          const split = match[0].split("-");
-          fromNounId = split[4];
-          toNounId = split[7];
-        } else {
-          const match = proposalCandidate.slug.match(/nounswap-swap-noun-[0-9]*-for-noun-[0-9]*/); // NounSwap v1: Swap Noun XX + ZZ WETH for Noun YY
-          if (match == null || match.length == 0) {
-            continue;
-          }
-          const split = match[0].split("-");
-          fromNounId = split[3];
-          toNounId = split[6];
-        }
-      }
-
-      const fromNoun = await getNounById(fromNounId);
-      const toNoun = await getNounById(toNounId);
-
-      swapNounCandidates.push({
-        id: proposalCandidate.id,
-        fromNoun: fromNoun,
-        toNoun: toNoun,
-        state: ProposalState.Candidate,
-      } as SwapNounProposal);
-    }
-
-    return [...swapNounCandidates, ...swapNounProposals];
-  } else {
+  if (!queryResult) {
     console.log(`getNounSwapProposalsForProposer: no proposals found - ${address}`);
     return [];
   }
+
+  const swapNounProposals: SwapNounProposal[] = [];
+
+  for (const proposal of queryResult.proposals.items) {
+    const parsed = parseSwapNounIds(proposal.title);
+    if (!parsed) continue;
+
+    const [fromNoun, toNoun] = await Promise.all([
+      getNounById(parsed.fromNounId),
+      getNounById(parsed.toNounId),
+    ]);
+
+    if (!fromNoun || !toNoun) continue;
+
+    const state = resolveProposalState(
+      proposal.lastKnownState,
+      currentBlock,
+      proposal.votingStartBlock,
+      proposal.votingEndBlock,
+      proposal.forVotes,
+      proposal.againstVotes,
+      proposal.quorumVotes,
+    );
+
+    swapNounProposals.push({
+      id: proposal.id,
+      fromNoun,
+      toNoun,
+      state,
+    });
+  }
+
+  return swapNounProposals;
 }

--- a/src/data/noun/getAllNouns.ts
+++ b/src/data/noun/getAllNouns.ts
@@ -1,108 +1,125 @@
 "use server";
 import { CHAIN_CONFIG } from "@/config";
-import { graphql } from "../generated/gql";
-import { graphQLFetchWithFallback } from "../utils/graphQLFetch";
-import { Noun } from "./types";
-import { AllNounsQuery } from "../generated/gql/graphql";
+import { Noun, SecondaryNounListing } from "./types";
 import { revalidateTag, unstable_cache } from "next/cache";
-import { transformQueryNounToNoun } from "./helpers";
+import { transformOnChainNounToNoun } from "./helpers";
 import { getSecondaryNounListings } from "./getSecondaryNounListings";
+import { nounsTokenAbi } from "@/abis/nounsToken";
+import { readContract, multicall } from "viem/actions";
+import { getAddress } from "viem";
+import { parseSeedTuple } from "./seedUtils";
 
-const BATCH_SIZE = 1000;
+const MULTICALL_BATCH_SIZE = 200;
 
-const query = graphql(/* GraphQL */ `
-  query AllNouns($batchSize: Int!, $skip: Int!) {
-    nouns(first: $batchSize, skip: $skip) {
-      id
-      owner {
-        id
+async function fetchAllNounsOnChainUncached(): Promise<
+  Omit<Noun, "secondaryListing">[]
+> {
+  const totalSupply = await readContract(CHAIN_CONFIG.publicClient, {
+    address: CHAIN_CONFIG.addresses.nounsToken,
+    abi: nounsTokenAbi,
+    functionName: "totalSupply",
+  });
+
+  const total = Number(totalSupply);
+  const nouns: Omit<Noun, "secondaryListing">[] = [];
+
+  for (let i = 0; i < total; i += MULTICALL_BATCH_SIZE) {
+    const batchSize = Math.min(MULTICALL_BATCH_SIZE, total - i);
+    const contracts = [];
+
+    for (let j = 0; j < batchSize; j++) {
+      const tokenId = BigInt(i + j);
+      contracts.push({
+        address: CHAIN_CONFIG.addresses.nounsToken,
+        abi: nounsTokenAbi,
+        functionName: "ownerOf" as const,
+        args: [tokenId] as const,
+      });
+      contracts.push({
+        address: CHAIN_CONFIG.addresses.nounsToken,
+        abi: nounsTokenAbi,
+        functionName: "seeds" as const,
+        args: [tokenId] as const,
+      });
+    }
+
+    const results = await multicall(CHAIN_CONFIG.publicClient, {
+      contracts,
+      allowFailure: true,
+    });
+
+    for (let j = 0; j < batchSize; j++) {
+      const ownerResult = results[j * 2];
+      const seedResult = results[j * 2 + 1];
+
+      if (
+        ownerResult.status !== "success" ||
+        seedResult.status !== "success"
+      ) {
+        continue;
       }
-      seed {
-        background
-        body
-        accessory
-        head
-        glasses
-      }
+
+      const owner = ownerResult.result as string;
+      const seed = seedResult.result as readonly [
+        number,
+        number,
+        number,
+        number,
+        number,
+      ];
+
+      nouns.push(
+        transformOnChainNounToNoun(
+          (i + j).toString(),
+          getAddress(owner),
+          parseSeedTuple(seed),
+        ),
+      );
     }
   }
-`);
 
-async function runPaginatedNounsQueryUncached() {
-  let queryNouns: AllNounsQuery["nouns"] = [];
-  let skip = 0;
-
-  while (true) {
-    const response = await graphQLFetchWithFallback(
-      CHAIN_CONFIG.subgraphUrl,
-      query,
-      { batchSize: BATCH_SIZE, skip },
-      { next: { revalidate: 0 } },
-    );
-    const responseNouns = response?.nouns;
-    if (!responseNouns) {
-      break;
-    }
-
-    queryNouns = queryNouns.concat(responseNouns);
-
-    if (responseNouns.length == BATCH_SIZE) {
-      skip += BATCH_SIZE;
-    } else {
-      break;
-    }
-  }
-
-  return queryNouns;
+  return nouns;
 }
 
-const runPaginatedNounsQuery = unstable_cache(
-  runPaginatedNounsQueryUncached,
-  ["run-paginated-nouns-query", CHAIN_CONFIG.chain.id.toString()],
+const fetchAllNounsOnChain = unstable_cache(
+  fetchAllNounsOnChainUncached,
+  ["fetch-all-nouns-onchain", CHAIN_CONFIG.chain.id.toString()],
   {
     revalidate: 5 * 60, // 5min
     tags: [`paginated-nouns-query-${CHAIN_CONFIG.chain.id.toString()}`],
   },
 );
 
+function sortDescendingById(nouns: Omit<Noun, "secondaryListing">[]): Omit<Noun, "secondaryListing">[] {
+  return [...nouns].sort((a, b) => (BigInt(b.id) > BigInt(a.id) ? 1 : -1));
+}
+
+function mergeWithListings(
+  nouns: Omit<Noun, "secondaryListing">[],
+  listings: SecondaryNounListing[],
+): Noun[] {
+  return nouns.map((noun) => ({
+    ...noun,
+    secondaryListing: listings.find((listing) => listing.nounId === noun.id) ?? null,
+  }));
+}
+
 export async function getAllNounsUncached(): Promise<Noun[]> {
-  const [queryResponse, secondaryNounListings] = await Promise.all([
-    runPaginatedNounsQueryUncached(),
+  const [onChainNouns, secondaryNounListings] = await Promise.all([
+    fetchAllNounsOnChainUncached(),
     getSecondaryNounListings(),
   ]);
-  let nouns = queryResponse.map(transformQueryNounToNoun);
 
-  // Sort by id, descending
-  nouns.sort((a, b) => (BigInt(b.id) > BigInt(a.id) ? 1 : -1));
-
-  const fullNouns = nouns.map((noun) => ({
-    ...noun,
-    secondaryListing: secondaryNounListings.find(
-      (listing) => listing.nounId === noun.id,
-    ),
-  })) as Noun[];
-
-  return fullNouns;
+  return mergeWithListings(sortDescendingById(onChainNouns), secondaryNounListings);
 }
 
 export async function getAllNouns(): Promise<Noun[]> {
-  const [queryResponse, secondaryNounListings] = await Promise.all([
-    runPaginatedNounsQuery(),
+  const [onChainNouns, secondaryNounListings] = await Promise.all([
+    fetchAllNounsOnChain(),
     getSecondaryNounListings(),
   ]);
-  let nouns = queryResponse.map(transformQueryNounToNoun);
 
-  // Sort by id, descending
-  nouns.sort((a, b) => (BigInt(b.id) > BigInt(a.id) ? 1 : -1));
-
-  const fullNouns = nouns.map((noun) => ({
-    ...noun,
-    secondaryListing: secondaryNounListings.find(
-      (listing) => listing.nounId === noun.id,
-    ),
-  })) as Noun[];
-
-  return fullNouns;
+  return mergeWithListings(sortDescendingById(onChainNouns), secondaryNounListings);
 }
 
 export async function forceAllNounRevalidation() {

--- a/src/data/noun/getNounById.ts
+++ b/src/data/noun/getNounById.ts
@@ -1,55 +1,77 @@
 "use server";
-import { Noun } from "./types";
-import { checkForAllNounRevalidation, forceAllNounRevalidation, getAllNouns } from "./getAllNouns";
-import { graphql } from "../generated/gql";
-import { graphQLFetchWithFallback } from "../utils/graphQLFetch";
-import { CHAIN_CONFIG } from "@/config";
-import { transformQueryNounToNoun } from "./helpers";
+import { getAddress } from "viem";
+import { readContract } from "viem/actions";
 import { unstable_cache } from "next/cache";
+import { nounsTokenAbi } from "@/abis/nounsToken";
+import { CHAIN_CONFIG } from "@/config";
 import { SECONDS_PER_HOUR } from "@/utils/constants";
+import { checkForAllNounRevalidation } from "./getAllNouns";
 import { getSecondaryListingForNoun } from "./getSecondaryNounListings";
+import { transformOnChainNounToNoun } from "./helpers";
+import { parseSeedTuple } from "./seedUtils";
+import { Noun } from "./types";
 
-const query = graphql(/* GraphQL */ `
-  query NounById($id: ID!) {
-    noun(id: $id) {
-      id
-      owner {
-        id
-      }
-      seed {
-        background
-        body
-        accessory
-        head
-        glasses
-      }
-    }
-  }
-`);
+async function fetchNounOnChain(
+  id: string,
+): Promise<Omit<Noun, "secondaryListing"> | undefined> {
+  try {
+    const [owner, seed] = await Promise.all([
+      readContract(CHAIN_CONFIG.publicClient, {
+        address: CHAIN_CONFIG.addresses.nounsToken,
+        abi: nounsTokenAbi,
+        functionName: "ownerOf",
+        args: [BigInt(id)],
+      }),
+      readContract(CHAIN_CONFIG.publicClient, {
+        address: CHAIN_CONFIG.addresses.nounsToken,
+        abi: nounsTokenAbi,
+        functionName: "seeds",
+        args: [BigInt(id)],
+      }),
+    ]);
 
-export async function getNounByIdUncached(id: string): Promise<Noun | undefined> {
-  const [response, secondaryListing] = await Promise.all([
-    graphQLFetchWithFallback(CHAIN_CONFIG.subgraphUrl, query, { id }, { next: { revalidate: 0 } }),
-    getSecondaryListingForNoun(id),
-  ]);
-  const noun = response ? transformQueryNounToNoun(response.noun as any) : undefined;
-
-  if (noun) {
-    checkForAllNounRevalidation(id);
-    const fullNoun: Noun = { ...noun, secondaryListing };
-    return fullNoun;
-  } else {
+    return transformOnChainNounToNoun(
+      id,
+      getAddress(owner),
+      parseSeedTuple(seed),
+    );
+  } catch (e) {
+    console.error("fetchNounOnChain - failed for id", id, e);
     return undefined;
   }
 }
 
-const getNounByIdCached = unstable_cache(getNounByIdUncached, ["get-noun-by-id"], { revalidate: SECONDS_PER_HOUR });
+// On-chain data (owner + seed) is cached for 1 hour. Seeds are immutable,
+// owner changes infrequently. Secondary listings are always fetched fresh.
+const fetchNounOnChainCached = unstable_cache(
+  fetchNounOnChain,
+  ["get-noun-by-id"],
+  { revalidate: SECONDS_PER_HOUR },
+);
 
-export async function getNounById(id: string): Promise<Noun | undefined> {
-  const [noun, secondaryListing] = await Promise.all([getNounByIdCached(id), getSecondaryListingForNoun(id)]);
+async function withSecondaryListing(
+  id: string,
+  onChainFetch: (id: string) => Promise<Omit<Noun, "secondaryListing"> | undefined>,
+): Promise<Noun | undefined> {
+  const [noun, secondaryListing] = await Promise.all([
+    onChainFetch(id),
+    getSecondaryListingForNoun(id),
+  ]);
 
-  // Kickoff a check to revalidate all in grid (when its a new Noun)
+  if (!noun) return undefined;
+
   checkForAllNounRevalidation(id);
+  return { ...noun, secondaryListing };
+}
 
-  return noun;
+export async function getNounByIdUncached(
+  id: string,
+): Promise<Noun | undefined> {
+  return withSecondaryListing(id, fetchNounOnChain);
+}
+
+export async function getNounById(
+  id: string,
+): Promise<Noun | undefined> {
+  return withSecondaryListing(id, fetchNounOnChainCached);
 }

--- a/src/data/noun/helpers.ts
+++ b/src/data/noun/helpers.ts
@@ -1,38 +1,26 @@
-import { getNounData } from "@/utils/nounImages/nounImage";
-import { AllNounsQuery } from "../generated/gql/graphql";
+import { getNounData, NounSeed } from "@/utils/nounImages/nounImage";
 import { Noun } from "./types";
-import { getAddress } from "viem";
+import { Address } from "viem";
 
-function extractNameFromFileName(filename: string) {
+function extractNameFromFileName(filename: string): string {
   return filename.substring(filename.indexOf("-") + 1);
 }
 
-// Async just so we can cache
-export function transformQueryNounToNoun(
-  queryNoun: AllNounsQuery["nouns"][0],
+export function transformOnChainNounToNoun(
+  id: string,
+  owner: Address,
+  seed: NounSeed,
 ): Omit<Noun, "secondaryListing"> {
-  if (!queryNoun.seed) {
-    throw new Error("Seed not found");
-  }
-
-  const seed = {
-    background: Number(queryNoun.seed.background),
-    body: Number(queryNoun.seed.body),
-    accessory: Number(queryNoun.seed.accessory),
-    head: Number(queryNoun.seed.head),
-    glasses: Number(queryNoun.seed.glasses),
-  };
-
-  const { parts, background } = getNounData(seed);
+  const { parts } = getNounData(seed);
   const [bodyPart, accessoryPart, headPart, glassesPart] = parts;
 
   return {
-    id: queryNoun.id,
-    owner: getAddress(queryNoun.owner.id),
+    id,
+    owner,
     traits: {
       background: {
         seed: seed.background,
-        name: queryNoun.seed.background == "0" ? "Cool" : "Warm",
+        name: seed.background === 0 ? "Cool" : "Warm",
       },
       body: {
         seed: seed.body,

--- a/src/data/noun/seedUtils.ts
+++ b/src/data/noun/seedUtils.ts
@@ -1,0 +1,13 @@
+import { NounSeed } from "@/utils/nounImages/nounImage";
+
+type SeedTuple = readonly [number, number, number, number, number];
+
+export function parseSeedTuple(seed: SeedTuple): NounSeed {
+  return {
+    background: Number(seed[0]),
+    body: Number(seed[1]),
+    accessory: Number(seed[2]),
+    head: Number(seed[3]),
+    glasses: Number(seed[4]),
+  };
+}

--- a/src/data/ponder/auction/getAuctionByNounId.ts
+++ b/src/data/ponder/auction/getAuctionByNounId.ts
@@ -1,0 +1,33 @@
+"use server";
+import { graphql } from "@/data/generated/ponder";
+import { graphQLFetch } from "@/data/utils/graphQLFetch";
+import { CHAIN_CONFIG } from "@/config";
+
+const query = graphql(/* GraphQL */ `
+  query AuctionByNounId($nounId: BigInt!) {
+    auction(nounsNftId: $nounId) {
+      nounsNftId
+      startTimestamp
+      endTimestamp
+      settled
+      bids(limit: 1000, orderBy: "amount", orderDirection: "desc") {
+        items {
+          transactionHash
+          bidderAccountAddress
+          amount
+          timestamp
+          clientId
+        }
+      }
+    }
+  }
+`);
+
+export async function fetchAuctionByNounId(nounId: string) {
+  return graphQLFetch(
+    CHAIN_CONFIG.ponderIndexerUrl,
+    query,
+    { nounId },
+    { cache: "no-cache" },
+  );
+}

--- a/src/data/ponder/governance/getNounSwapProposals.ts
+++ b/src/data/ponder/governance/getNounSwapProposals.ts
@@ -1,0 +1,37 @@
+"use server";
+import { graphql } from "@/data/generated/ponder";
+import { graphQLFetch } from "@/data/utils/graphQLFetch";
+import { CHAIN_CONFIG } from "@/config";
+
+const query = graphql(/* GraphQL */ `
+  query NounSwapProposals($proposer: String!) {
+    proposals(
+      limit: 1000
+      where: { proposerAddress: $proposer, title_contains: "NounSwap" }
+      orderBy: "id"
+      orderDirection: "desc"
+    ) {
+      items {
+        id
+        title
+        description
+        proposerAddress
+        quorumVotes
+        forVotes
+        againstVotes
+        lastKnownState
+        votingStartBlock
+        votingEndBlock
+      }
+    }
+  }
+`);
+
+export async function fetchNounSwapProposals(proposer: string) {
+  return graphQLFetch(
+    CHAIN_CONFIG.ponderIndexerUrl,
+    query,
+    { proposer },
+    { cache: "no-cache" },
+  );
+}

--- a/src/data/utils/graphQLFetch.ts
+++ b/src/data/utils/graphQLFetch.ts
@@ -1,5 +1,4 @@
 import { GraphQLError } from "graphql";
-import { TypedDocumentString as SubgraphTypedDocumentString } from "../generated/gql/graphql";
 import { TypedDocumentString as PonderTypedDocumentString } from "../generated/ponder/graphql";
 import { TypedDocumentString as CmsTypedDocumentString } from "../generated/cms/graphql";
 import { safeFetch } from "@/utils/safeFetch";
@@ -14,7 +13,6 @@ export interface CacheConfig {
 export async function graphQLFetch<Result, Variables>(
   url: string,
   query:
-    | SubgraphTypedDocumentString<Result, Variables>
     | PonderTypedDocumentString<Result, Variables>
     | CmsTypedDocumentString<Result, Variables>,
   variables?: Variables,
@@ -46,22 +44,4 @@ export async function graphQLFetch<Result, Variables>(
   }
 
   return result.data;
-}
-
-export async function graphQLFetchWithFallback<Result, Variables>(
-  url: { primary: string; fallback: string },
-  query:
-    | SubgraphTypedDocumentString<Result, Variables>
-    | PonderTypedDocumentString<Result, Variables>,
-  variables?: Variables,
-  cacheConfig?: CacheConfig,
-): Promise<Result | null> {
-  let result = await graphQLFetch(url.primary, query, variables, cacheConfig);
-
-  if (!result) {
-    console.log("Graphql primary failed, trying fallback...");
-    result = await graphQLFetch(url.fallback, query, variables, cacheConfig);
-  }
-
-  return result;
 }

--- a/src/utils/nounImages/nounImage.ts
+++ b/src/utils/nounImages/nounImage.ts
@@ -7,13 +7,21 @@ const { bodies, accessories, heads, glasses } = imageData.images;
 
 export type NounImageType = "full" | NounTraitType;
 
+export interface NounSeed {
+  background: number;
+  body: number;
+  accessory: number;
+  head: number;
+  glasses: number;
+}
+
 export function buildBase64Image(
   parts: {
     data: string;
   }[],
   bgColor?: string,
   cropViewBox?: string,
-) {
+): string {
   let svg = buildSVG(parts, palette, bgColor);
 
   if (cropViewBox) {
@@ -25,21 +33,17 @@ export function buildBase64Image(
   return "data:image/svg+xml;base64," + svgBase64;
 }
 
-export function getNounData(seed: {
-  background: number;
-  body: number;
-  accessory: number;
-  head: number;
-  glasses: number;
-}) {
+const PLACEHOLDER_PART = { filename: "unknown", data: "0x0" };
+
+export function getNounData(seed: NounSeed) {
   return {
     parts: [
-      bodies[seed.body],
-      accessories[seed.accessory],
-      heads[seed.head],
-      glasses[seed.glasses],
+      bodies[seed.body] ?? PLACEHOLDER_PART,
+      accessories[seed.accessory] ?? PLACEHOLDER_PART,
+      heads[seed.head] ?? PLACEHOLDER_PART,
+      glasses[seed.glasses] ?? PLACEHOLDER_PART,
     ],
-    background: bgcolors[seed.background],
+    background: bgcolors[seed.background] ?? bgcolors[0],
   };
 }
 
@@ -89,25 +93,25 @@ export function buildNounTraitImage(
   seed: number,
 ): string {
   const data = getPartData(traitType, seed);
-  let viewBox = TRAIT_TYPE_VIEW_BOX[traitType];
+  const viewBox = TRAIT_TYPE_VIEW_BOX[traitType];
 
   return buildBase64Image(
     [{ data }],
-    traitType == "background" ? bgcolors[seed] : undefined,
+    traitType === "background" ? bgcolors[seed] : undefined,
     viewBox,
   );
 }
 
-function getPartData(traitType: NounTraitType, seed: number) {
+function getPartData(traitType: NounTraitType, seed: number): string {
   switch (traitType) {
     case "head":
-      return heads[seed].data;
+      return heads[seed]?.data ?? PLACEHOLDER_PART.data;
     case "glasses":
-      return glasses[seed].data;
+      return glasses[seed]?.data ?? PLACEHOLDER_PART.data;
     case "body":
-      return bodies[seed].data;
+      return bodies[seed]?.data ?? PLACEHOLDER_PART.data;
     case "accessory":
-      return accessories[seed].data;
+      return accessories[seed]?.data ?? PLACEHOLDER_PART.data;
     case "background":
       return ""; // TODO
   }


### PR DESCRIPTION
## Summary
- Both Nouns subgraph endpoints went down, causing `getAllNouns()` to return `[]` and crashing `FloatingNounsBackground` with `TypeError: Cannot read properties of undefined (reading 'id')`
- Migrates all 5 subgraph consumers to direct on-chain RPC calls (viem multicall) and Ponder GraphQL indexer
- Fixes stale secondary listing cache (was baked into 1hr noun cache), adds stale-while-revalidate resilience for `getCurrentAuctionNounId`, removes dead `graphQLFetchWithFallback` code, adds null safety for swap proposals
